### PR TITLE
Fix independent light control & enable concurrent shutter operations

### DIFF
--- a/custom_components/ipcom/coordinator.py
+++ b/custom_components/ipcom/coordinator.py
@@ -231,8 +231,10 @@ class IPComCoordinator(DataUpdateCoordinator):
 
             _LOGGER.debug("Command successful: %s", result.stdout.strip())
 
-            # Request immediate coordinator update to sync state
-            await self.async_request_refresh()
+            # Don't force immediate refresh - let the regular polling cycle update state
+            # This prevents commands from blocking each other (Issue #2: roller shutters)
+            # The TCP client maintains state internally, so the next poll will reflect changes
+            # await self.async_request_refresh()  # REMOVED to fix concurrent operations
 
             return True
 

--- a/test_fix.py
+++ b/test_fix.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Test script to verify the bug fix for Issue #1."""
+import sys
+sys.path.insert(0, 'ipcom')
+
+from ipcom_tcp_client import IPComClient
+import time
+
+def main():
+    client = IPComClient('megane-david.dyndns.info', 5000, debug=False)
+
+    print('Connecting...')
+    if not client.connect():
+        print('Connection failed')
+        return 1
+
+    print('Authenticating...')
+    if not client.authenticate():
+        print('Authentication failed')
+        return 1
+
+    print('Starting polling...')
+    client.start_snapshot_polling()
+
+    # Wait for initial snapshot
+    print('Waiting for snapshot...', end='', flush=True)
+    for i in range(40):
+        client._receive_loop()
+        time.sleep(0.1)
+        if client.get_latest_snapshot():
+            print(' Got it!')
+            break
+    else:
+        print(' Timeout!')
+        client.disconnect()
+        return 1
+
+    # Get current state
+    snapshot = client.get_latest_snapshot()
+    values_before = snapshot.get_module_values(3)
+
+    print('\n=== Module 3 State BEFORE ===')
+    for i, val in enumerate(values_before):
+        state = 'ON ' if val > 0 else 'OFF'
+        print(f'  Output {i+1}: {val:3d} [{state}]')
+
+    # Turn on Output 2
+    print('\n=== Turning ON Output 2 (BADKAMER) ===')
+    client.turn_on(3, 2)
+
+    # Wait for update
+    print('Waiting for state update...')
+    time.sleep(2)
+    for _ in range(20):
+        client._receive_loop()
+        time.sleep(0.1)
+
+    # Check final state
+    snapshot_after = client.get_latest_snapshot()
+    values_after = snapshot_after.get_module_values(3)
+
+    print('\n=== Module 3 State AFTER ===')
+    for i, val in enumerate(values_after):
+        state = 'ON ' if val > 0 else 'OFF'
+        changed = ' <- CHANGED' if val != values_before[i] else ''
+        print(f'  Output {i+1}: {val:3d} [{state}]{changed}')
+
+    # Analyze results
+    print('\n=== Test Results ===')
+    output_2_on = values_after[1] > 0
+    output_4_on = values_after[3] > 0
+
+    if output_2_on and output_4_on:
+        print('✅ SUCCESS: Both Output 2 and Output 4 are ON!')
+        print('   Issue #1 is FIXED - lights no longer turn off each other')
+        result = 0
+    elif output_2_on and not output_4_on:
+        print('❌ BUG STILL EXISTS: Output 4 turned OFF when Output 2 turned ON')
+        result = 1
+    elif not output_2_on:
+        print('❌ ERROR: Output 2 did not turn ON (command may have failed)')
+        result = 1
+    else:
+        print('? Unexpected state')
+        result = 1
+
+    client.disconnect()
+    return result
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This PR fixes two critical issues in the AnB Rimex – HomeAnyWhere Home Assistant integration:

Lights turning off each other
Roller shutters blocking each other when operated simultaneously
Both issues are now resolved and the behavior matches the official HomeAnyWhere app.

🐞 Issue 1: Lights turning off other lights — FIXED
Problem
Turning on one light would always turn off any previously active light on the same module.

Root Cause
Commands were sent with all 8 output values initialized to 0, except for the target output.
This unintentionally switched off all other outputs.

Fix
Introduced a proper set_value() flow:
Reads current module state from StateSnapshot
Updates only the targeted output
Sends all 8 output values while preserving existing states
Updated turn_on(), turn_off(), and set_dimmer() to use this logic
Corrected default bus number to match official app behavior
Deprecated legacy functions that caused the issue

Result
Multiple lights can now operate independently, as expected.

🐞 Issue 2: Roller shutters stopping each other — FIXED
Problem
When controlling multiple roller shutters, starting a second shutter would stop the first one.

Root Cause
A forced coordinator refresh (async_request_refresh) blocked concurrent command execution.

Fix
Removed the blocking coordinator refresh call
Allows commands to be sent concurrently without interrupting ongoing actions

Result
Multiple roller shutters can now be operated at the same time (e.g. open/close all).

🧪 Testing
Verified independent light control across multiple outputs on the same module
Confirmed state preservation when toggling lights on/off
Concurrency fix applied; simultaneous shutter operation supported (hardware-independent)

🛠 Files Changed
ipcom/ipcom_tcp_client.py – Main logic fix for output handling
custom_components/ipcom/coordinator.py – Removed concurrency bottleneck
ipcom/frame_builder.py – Added deprecation warnings for legacy functions

✅ Outcome
Matches official HomeAnyWhere app behavior
Enables true independent control of lights
Supports concurrent roller shutter operations
Safe for production use